### PR TITLE
ci: Check snapshots on macOS too

### DIFF
--- a/.github/workflows/scip-snapshot.yml
+++ b/.github/workflows/scip-snapshot.yml
@@ -10,7 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Install asdf.


### PR DESCRIPTION
If https://github.com/sourcegraph/scip-python/pull/138 is meant to fix that issue,
we should turn on CI testing on macOS to make sure we don't regress it.

I was unable to push to the branch directly because of permissions
(and I was unable to accept the invitation to collaborate on the repo
due to a " Sorry, we couldn't find that repository invitation. It is possible
that the invitation was revoked or that you are not logged into the
invited account." error message), so I've made a PR.